### PR TITLE
Add branch name to run tags in AML workspace

### DIFF
--- a/.github/workflows/platform_ci_dev_workflow.yml
+++ b/.github/workflows/platform_ci_dev_workflow.yml
@@ -47,15 +47,11 @@ jobs:
       RESOURCE_GROUP_NAME: ${{ vars.RESOURCE_GROUP_NAME }}
       WORKSPACE_NAME: ${{ vars.WORKSPACE_NAME }}
     steps:
-      - name: test step
-        run: |
-          echo "HELLO THIS IS THE FIRST STEP"
-
       - name: Checkout repo and llmops utils
         uses: equinor/genaiops-promptflow-template/.github/actions/checkout_llmops@reusable-external
         with:
           llmops_repository: equinor/genaiops-promptflow-template
-          llmops_ref: feature/branch-name
+          llmops_ref: reusable-external
 
       - name: Azure login
         uses: azure/login@v1

--- a/.github/workflows/platform_ci_dev_workflow.yml
+++ b/.github/workflows/platform_ci_dev_workflow.yml
@@ -51,7 +51,7 @@ jobs:
         uses: equinor/genaiops-promptflow-template/.github/actions/checkout_llmops@reusable-external
         with:
           llmops_repository: equinor/genaiops-promptflow-template
-          llmops_ref: reusable-external
+          llmops_ref: feature/branch-name
 
       - name: Azure login
         uses: azure/login@v1

--- a/.github/workflows/platform_ci_dev_workflow.yml
+++ b/.github/workflows/platform_ci_dev_workflow.yml
@@ -47,6 +47,10 @@ jobs:
       RESOURCE_GROUP_NAME: ${{ vars.RESOURCE_GROUP_NAME }}
       WORKSPACE_NAME: ${{ vars.WORKSPACE_NAME }}
     steps:
+      - name: test step
+        run: |
+          echo "HELLO THIS IS THE FIRST STEP"
+
       - name: Checkout repo and llmops utils
         uses: equinor/genaiops-promptflow-template/.github/actions/checkout_llmops@reusable-external
         with:

--- a/.github/workflows/platform_ci_dev_workflow.yml
+++ b/.github/workflows/platform_ci_dev_workflow.yml
@@ -111,6 +111,7 @@ jobs:
             python -m llmops.common.prompt_pipeline \
             --subscription_id ${{ steps.subscription_details.outputs.SUBSCRIPTION_ID }} \
             --build_id ${{ github.run_id }} \
+            --branch ${{ github.head_ref || github.ref_name }} \
             --base_path ${{ inputs.use_case_base_path }} \
             --env_name ${{ inputs.env_name }} \
             --output_file run_id.txt
@@ -160,6 +161,7 @@ jobs:
             python -m llmops.common.prompt_eval \
             --subscription_id ${{ steps.subscription_details.outputs.SUBSCRIPTION_ID }} \
             --build_id ${{ github.run_id }} \
+            --branch ${{ github.head_ref || github.ref_name }} \
             --base_path ${{ inputs.use_case_base_path }} \
             --env_name ${{ inputs.env_name }} \
             --run_id "$RUN_NAME" \

--- a/llmops/common/prompt_eval.py
+++ b/llmops/common/prompt_eval.py
@@ -9,6 +9,8 @@ and experiment.yaml are expected to be found.
 specified, the SUBSCRIPTION_ID environment variable is expected to be provided.
 --build_id: The unique identifier for build execution.
 This argument is not required but will be added as a run tag if specified.
+--branch: the branch in the repo where the pipeline is running from.
+This argument is not required but will be added as a run tag if specified.
 --env_name: The environment name for execution and deployment. This argument
 is not required but will be used to read experiment overlay files if specified.
 --run_id: Run ids of runs to be evaluated (File or comma separated string)
@@ -63,6 +65,7 @@ def prepare_and_execute(
     base_path: Optional[str] = None,
     subscription_id: Optional[str] = None,
     build_id: Optional[str] = None,
+    branch: Optional[str] = None,
     env_name: Optional[str] = None,
     report_dir: Optional[str] = None,
     save_metrics_only: Optional[bool] = False,
@@ -208,6 +211,8 @@ def prepare_and_execute(
                 run_tags = {"data": dataset.name}
                 if build_id:
                     run_tags["build_id"] = build_id
+                if branch:
+                    run_tags["branch"] = branch
 
                 evaluator_executed = True
                 # Create run object
@@ -455,6 +460,7 @@ def prepare_and_execute(
         final_results_df["stage"] = env_name
         final_results_df["experiment_name"] = experiment_name
         final_results_df["build"] = build_id
+        final_results_df["branch"] = branch
 
         allresults_basename = f"{report_dir}/{experiment_name}_result"
         final_results_df.to_csv(f"{allresults_basename}.csv")
@@ -504,6 +510,12 @@ def main():
         default=None,
     )
     parser.add_argument(
+        "--branch",
+        type=str,
+        help="Branch name in the repository",
+        default=None,
+    )
+    parser.add_argument(
         "--run_id",
         type=str,
         required=True,
@@ -531,6 +543,7 @@ def main():
         args.base_path,
         args.subscription_id,
         args.build_id,
+        args.branch,
         args.env_name,
         args.report_dir,
         args.save_metrics_only,

--- a/llmops/common/prompt_pipeline.py
+++ b/llmops/common/prompt_pipeline.py
@@ -13,6 +13,8 @@ and experiment.yaml are expected to be found.
 specified, the SUBSCRIPTION_ID environment variable is expected to be provided.
 --build_id: The unique identifier for build execution.
 This argument is not required but will be added as a run tag if specified.
+--branch: the branch in the repo where the pipeline is running from.
+This argument is not required but will be added as a run tag if specified.
 --env_name: The environment name for execution and deployment. This argument
 is not required but will be used to read experiment overlay files if specified.
 --output_file: A file path to save run IDs. This argument is not required
@@ -142,6 +144,7 @@ def prepare_and_execute(
     subscription_id: Optional[str] = None,
     report_dir: Optional[str] = None,
     build_id: Optional[str] = None,
+    branch: Optional[str] = None,
     env_name: Optional[str] = None,
     output_file: Optional[str] = None,
     save_output: Optional[bool] = None,
@@ -219,6 +222,8 @@ def prepare_and_execute(
         run_tags = {"data": dataset.name}
         if build_id:
             run_tags["build_id"] = build_id
+        if branch:
+            run_tags["branch"] = branch
 
         dataframes = []
         metrics = []
@@ -472,6 +477,7 @@ def prepare_and_execute(
         final_results_df["stage"] = env_name
         final_results_df["experiment_name"] = experiment.name
         final_results_df["build"] = build_id
+        final_results_df["branch"] = branch
         final_results_df.to_csv(f"./{report_dir}/{experiment.name}_result.csv")
         styled_df = final_results_df.to_html(index=False)
         with open(
@@ -540,6 +546,12 @@ def main():
         default=None,
     )
     parser.add_argument(
+        "--branch",
+        type=str,
+        help="Branch name in the repository",
+        default=None,
+    )
+    parser.add_argument(
         "--report_dir",
         type=str,
         default="./reports",
@@ -569,6 +581,7 @@ def main():
         args.subscription_id,
         args.report_dir,
         args.build_id,
+        args.branch,
         args.env_name,
         args.output_file,
         args.save_output,


### PR DESCRIPTION
Add branch name to run tags in AML workspace, both when pipeline is manually run from a branch and when it's triggered via PR